### PR TITLE
Added missing return to formatData

### DIFF
--- a/src/plugins/views/editors/Node/components/KeyValueTable/KeyValueTable.jsx
+++ b/src/plugins/views/editors/Node/components/KeyValueTable/KeyValueTable.jsx
@@ -34,7 +34,7 @@ const KeyValueTable = props => {
    */
   const formatData = _data => {
     if (Array.isArray(_data)) return _data;
-    Object.values(_data).map((item, i) => {
+    return Object.values(_data).map((item, i) => {
       return {
         id: `${i}_${item.name}`,
         name: item.name,


### PR DESCRIPTION
In a previous commit (68bee81da060a17aa369060f210527cf473d6907) I accidentally removed a return that is needed on this function to actually return the values.

This PR is just to add it back.