### PR TITLE
Added hotkeys.filter to allow the save on inputs

### DIFF
--- a/src/decorators/withKeyBinds.jsx
+++ b/src/decorators/withKeyBinds.jsx
@@ -1,6 +1,10 @@
 import React from "react";
 import hotkeys from "hotkeys-js";
 
+/**
+ * By default hotkeys are not enabled for INPUT SELECT TEXTAREA elements.
+ * Hotkeys.filter to return to the true shortcut keys set to play a role, false shortcut keys set up failure.
+ */
 hotkeys.filter = function (event) {
   return true;
 };


### PR DESCRIPTION
When using textareas / inputs / selects / checkboxes the **hotkeys** plugin would lose it's activeKeyBinds.

Adding this hotkeys.filter fixes this issue.