### PR TITLE
FP-1312 :  Add missing validation to new document creation

### DIFF
--- a/src/plugins/Dialog/components/FormDialog/hooks/useNewDocument.js
+++ b/src/plugins/Dialog/components/FormDialog/hooks/useNewDocument.js
@@ -6,14 +6,21 @@ const useNewDocument = ({ call, scope }) => {
   /**
    * Triggered before submit
    * @param {String} value : New document modal's value
-   * @returns Validation state
+   * @returns Validation state : Should accept alphanumeric with dash and underscore (doesn't accept double undescore)
    */
   const onValidation = value => {
-    const isEmpty = !value;
-    return {
-      result: !isEmpty,
-      error: isEmpty ? "Document name is required" : ""
-    };
+    try {
+      const validation = new RegExp(/^[\w][0-9A-Za-z-]*(_[0-9A-Za-z-]+)*[_]?$/);
+      if (!validation.test(value)) {
+        throw new Error("Invalid name");
+      }
+      return { result: true, error: "" };
+    } catch (err) {
+      return {
+        result: false,
+        error: err.message
+      };
+    }
   };
 
   /**


### PR DESCRIPTION
New document creation accept only alphanumeric, dashes and underscores (double underscore is not allowed)