### PR TITLE
[FP - 1524] After saving we couldn't update other properties

### DIFF
--- a/src/engine/ReactPlugin/EditorReactPlugin.js
+++ b/src/engine/ReactPlugin/EditorReactPlugin.js
@@ -4,8 +4,8 @@ import withKeyBinds from "../../decorators/withKeyBinds";
 import withMenuHandler from "../../decorators/withMenuHandler";
 import withLoader from "../../decorators/withLoader";
 import { withDataHandler } from "../../plugins/DocManager/DataHandler";
-import { ViewPlugin } from "./ViewReactPlugin";
 import { PLUGINS } from "../../utils/Constants";
+import { ViewPlugin } from "./ViewReactPlugin";
 
 /**
  * Add decorators to Component always forwarding ref
@@ -80,6 +80,9 @@ export function withEditorPlugin(ReactComponent, methods = []) {
      */
     const saveDocument = React.useCallback(() => {
       // If document is outdated
+
+      if (!instance.current.isDirty) return;
+
       if (instance.current.getOutdated()) {
         call("dialog", "saveOutdatedDocument", {
           name,

--- a/src/models/Flow/subModels/Link/Link.js
+++ b/src/models/Flow/subModels/Link/Link.js
@@ -107,7 +107,7 @@ class Link extends Model {
     ID: "id",
     FROM: "from",
     TO: "to",
-    DEPENDENCY: "dependecy"
+    DEPENDENCY: "dependency"
   };
 }
 

--- a/src/models/Flow/subModels/NodeInstance/NodeInstance.js
+++ b/src/models/Flow/subModels/NodeInstance/NodeInstance.js
@@ -342,7 +342,7 @@ class NodeInstance extends Model {
       groups: this.getGroups(),
       position: this.getPosition().serialize(),
       parameters: this.getParameters().serialize(),
-      envvars: this.getEnvVars().serialize(),
+      envVars: this.getEnvVars().serialize(),
       commands: this.getCommands().serialize()
     };
   }
@@ -395,7 +395,7 @@ class NodeInstance extends Model {
       NodeLayers: groups,
       Visualization: position,
       Parameter: parameters,
-      EnvVar: envvars,
+      EnvVar: envVars,
       CmdLine: commands
     } = content;
 
@@ -408,7 +408,7 @@ class NodeInstance extends Model {
       groups,
       position: Position.serializeOfDB(position),
       parameters: Manager.serializeOfDB(parameters, Parameter),
-      envVars: Manager.serializeOfDB(envvars, EnvVar),
+      envVars: Manager.serializeOfDB(envVars, EnvVar),
       commands: Manager.serializeOfDB(commands, Command)
     };
   }

--- a/src/plugins/Dialog/Dialog.js
+++ b/src/plugins/Dialog/Dialog.js
@@ -46,7 +46,7 @@ class Dialog extends IDEPlugin {
       <AlertDialog
         title={data.title}
         message={data.message}
-        onClose={this._handleDialogClose}
+        onClose={() => this._handleDialogClose(data.onClose)}
       />,
       targetElement
     );
@@ -64,7 +64,7 @@ class Dialog extends IDEPlugin {
         onSubmit={data.onSubmit}
         message={data.message}
         submitText={data.submitText}
-        onClose={this._handleDialogClose}
+        onClose={() => this._handleDialogClose(data.onClose)}
       />,
       targetElement
     );
@@ -83,7 +83,7 @@ class Dialog extends IDEPlugin {
         submitText={"Create"}
         scope={data.scope}
         onSubmit={data.onSubmit}
-        onClose={this._handleDialogClose}
+        onClose={() => this._handleDialogClose(data.onClose)}
       />,
       targetElement
     );
@@ -103,7 +103,7 @@ class Dialog extends IDEPlugin {
         loadingMessage={"Copying document"}
         submitText={"Copy"}
         onSubmit={data.onSubmit}
-        onClose={this._handleDialogClose}
+        onClose={() => this._handleDialogClose(data.onClose)}
       />,
       targetElement
     );
@@ -137,10 +137,7 @@ class Dialog extends IDEPlugin {
         submitText={submitText}
         onSubmit={onSubmit}
         onValidation={onValidation}
-        onClose={() => {
-          this._handleDialogClose();
-          onClose && onClose();
-        }}
+        onClose={() => this._handleDialogClose(onClose)}
       />,
       targetElement
     );
@@ -168,7 +165,7 @@ class Dialog extends IDEPlugin {
         message={message}
         actions={actions}
         onSubmit={data.onSubmit}
-        onClose={this._handleDialogClose}
+        onClose={() => this._handleDialogClose(data.onClose)}
       />,
       targetElement
     );
@@ -193,7 +190,7 @@ class Dialog extends IDEPlugin {
         message={message}
         actions={actions}
         onSubmit={data.onSubmit}
-        onClose={this._handleDialogClose}
+        onClose={() => this._handleDialogClose(data.onClose)}
       />,
       targetElement
     );
@@ -214,7 +211,7 @@ class Dialog extends IDEPlugin {
         actions={actions}
         submitText={submitText}
         onSubmit={onSubmit}
-        onClose={this._handleDialogClose}
+        onClose={() => this._handleDialogClose(data.onClose)}
       >
         <Component {...props} />
       </AppDialog>,
@@ -224,14 +221,17 @@ class Dialog extends IDEPlugin {
 
   /**
    * Show custom dialog component
-   * @param {*} props : Props to pass to DialogComponent
+   * @param {*} data : Props to pass to DialogComponent
    * @param {ReactComponent} DialogComponent : Custom dialog component
    */
-  customDialog(props, DialogComponent) {
+  customDialog(data, DialogComponent) {
     const targetElement = this._handleDialogOpen();
     // Show dialog
     ReactDOM.render(
-      <DialogComponent {...props} onClose={this._handleDialogClose} />,
+      <DialogComponent
+        {...data}
+        onClose={() => this._handleDialogClose(data.onClose)}
+      />,
       targetElement
     );
   }
@@ -259,7 +259,7 @@ class Dialog extends IDEPlugin {
         selected={selected}
         allowArchive={false}
         scopeList={scopeList}
-        onCancel={this._handleDialogClose}
+        onCancel={() => this._handleDialogClose(data.onClose)}
         onSubmit={handleDialogSubmit}
       />,
       targetElement
@@ -288,11 +288,12 @@ class Dialog extends IDEPlugin {
   /**
    * @private Handle dialog close : Unmount dialog component and remove target element
    */
-  _handleDialogClose() {
+  _handleDialogClose(onClose) {
     document.body.classList.remove(Dialog.BODY_CLASS_NAME);
     const targetElement = document.getElementById(Dialog.TARGET_ELEMENT_ID);
     ReactDOM.unmountComponentAtNode(targetElement);
     targetElement.parentNode.removeChild(targetElement);
+    onClose && onClose();
   }
 
   //========================================================================================

--- a/src/plugins/DocManager/DataHandler.jsx
+++ b/src/plugins/DocManager/DataHandler.jsx
@@ -1,14 +1,15 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 const MESSAGES = {
-  save: {
-    success: "Saved successfully",
-    error: "Failed to save"
+  SAVE: {
+    SUCCESS: "Saved successfully",
+    ERROR: "Failed to save"
   }
 };
 
 const DataHandler = props => {
-  const { children, call, scope, name, id, alert } = props;
+  const { children, call, scope, name, id, alert, alertSeverities } = props;
   const [data, setData] = React.useState();
   const [loading, setLoading] = React.useState(true);
   const modelRef = React.useRef();
@@ -23,7 +24,10 @@ const DataHandler = props => {
     call("docManager", "save", { scope, name }, newName)
       .then(res => {
         if (res.success) {
-          alert({ message: t(MESSAGES.save.success), severity: "success" });
+          alert({
+            message: t(MESSAGES.SAVE.SUCCESS),
+            severity: alertSeverities.SUCCESS
+          });
           if (newName) {
             const newTabData = {
               id: modelRef.current.getUrl(),
@@ -33,12 +37,18 @@ const DataHandler = props => {
             call("tabs", "updateTabId", id, newTabData);
           }
         } else {
-          alert({ message: t(MESSAGES.save.error), severity: "error" });
+          alert({
+            message: t(MESSAGES.SAVE.ERROR),
+            severity: alertSeverities.ERROR
+          });
         }
       })
       .catch(error => {
         console.log("Failed to save: error", error);
-        alert({ message: t(MESSAGES.save.error), severity: "error" });
+        alert({
+          message: t(MESSAGES.SAVE.ERROR),
+          severity: alertSeverities.ERROR
+        });
       });
   };
 
@@ -71,7 +81,3 @@ const withDataHandler = Component => {
 export default DataHandler;
 
 export { withDataHandler };
-
-function useTranslation() {
-  return { t: s => s };
-}

--- a/src/plugins/views/editors/Flow/Components/Nodes/ContainerNode.js
+++ b/src/plugins/views/editors/Flow/Components/Nodes/ContainerNode.js
@@ -24,7 +24,7 @@ class ContainerNode extends BaseContainerNode {
    * Remove init method of the base class
    */
   init() {
-    // Empty on purpose
+    return this;
   }
 
   /**

--- a/src/plugins/views/editors/_shared/hooks/DataTypes/types/ArrayType.js
+++ b/src/plugins/views/editors/_shared/hooks/DataTypes/types/ArrayType.js
@@ -22,7 +22,7 @@ class ArrayType extends DataType {
    * @returns
    */
   validate(value) {
-    value = value.replace(/'/g, '"');
+    value = value?.replace(/'/g, '"');
     return new Promise(resolve => {
       try {
         if (checkIfDefaultOrDisabled(value)) {


### PR DESCRIPTION
- Added a verification to check if document is not dirty, we don't need to go through the save process.
- Fixed a bug where dependency link had a typo and wasn't correctly updating the `isDirty` flag.
- Fixed a typo where we were using `envVars` on some places and `envvars` on others. Now we always use `envVars`.
- Fixed a bug where after closing some modals, the keybinds weren't being reinstanted correctly.
- Fixed an issue where after saving something on Flow Editor, we couldn't change any node properties.
- Minor refactors