### PR TITLE
[FP - 1543] - Fixed the issue with examples not showing on release

### DIFF
--- a/database/Configuration/app-ide-ce.yaml
+++ b/database/Configuration/app-ide-ce.yaml
@@ -56,7 +56,7 @@ Languages:
       "Are you sure you want to delete": "Are you sure you want to delete"
       "Are you sure you want to delete all": "Are you sure you want to delete all"
       "Are you sure you want to delete layer": "Are you sure you want to delete layer"
-      'Are you sure you want to delete the param "{{paramName}}" with the value "{{value}}"?': 'Are you sure you want to delete the parameter "{{paramName}}" with the value "{{value}}"?'
+      "Are you sure you want to delete the param '{{paramName}}' with the value '{{value}}'?": "Are you sure you want to delete the parameter '{{paramName}}' with the value '{{value}}'?"
       "Backup": "Backup"
       "Belongs to": "Belongs to"
       "Callback": "Callback"
@@ -77,7 +77,7 @@ Languages:
       "Configurations": "Configurations"
       "Configuration Details Menu": "Configuration Details Menu"
       "Confirm to delete": "Confirm to delete"
-      'Confirm to delete "{{paramName}}"': 'Confirm to delete "{{paramName}}"'
+      "Confirm to delete '{{paramName}}'": "Confirm to delete '{{paramName}}'"
       "Controls whether the Node is to be launched or not": "Controls whether the Node is to be launched or not"
       "copied": "copied"
       "Copy": "Copy"
@@ -301,7 +301,7 @@ Languages:
       "Are you sure you want to delete": "Tem certeza de que deseja excluir"
       "Are you sure you want to delete all": "Tem certeza que quer apagar todos"
       "Are you sure you want to delete layer": "Tens a certeza de que deseja remover a camada"
-      'Are you sure you want to delete the param "{{paramName}}" with the value "{{value}}"?': 'Tem a certeza que deseja apagar o Parâmetro "{{paramName}}" que tem o valor "{{value}}"?'
+      "Are you sure you want to delete the param '{{paramName}}' with the value '{{value}}'?": "Tem a certeza que deseja apagar o Parâmetro '{{paramName}}' que tem o valor '{{value}}'?"
       "Backup": "Cópia de segurança"
       "Belongs to": "Pertence a"
       "Callback": "Callback"
@@ -322,7 +322,7 @@ Languages:
       "Configurations": "Configurações"
       "Configuration Details Menu": "Menu de detalhes da Configuração"
       "Confirm to delete": "Confirme para excluir"
-      'Confirm to delete "{{paramName}}"': 'Confirme para apagar "{{paramName}}"'
+      "Confirm to delete '{{paramName}}'": "Confirme para apagar '{{paramName}}'"
       "Controls whether the Node is to be launched or not": "Controla se o Nó deve ser lançado ou não"
       "copied": "copiado"
       "Copy": "Copiar"


### PR DESCRIPTION
Examples were not showing.
The Configuration.yaml file had some strings surrounded with `'` instead of `"`, this was causing the SERVER_DATA to fail to be correctly parsed.