### PR TITLE
Quick bump lib react to 1.0.37

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@material-ui/styles": "^4.11.4",
         "@mov-ai/mov-fe-lib-code-editor": "^1.0.6",
         "@mov-ai/mov-fe-lib-core": "^1.0.36",
-        "@mov-ai/mov-fe-lib-react": "^1.0.34",
+        "@mov-ai/mov-fe-lib-react": "^1.0.37",
         "@remixproject/engine": "^0.3.19",
         "@remixproject/engine-web": "^0.3.19",
         "@testing-library/jest-dom": "^5.14.1",
@@ -3578,9 +3578,9 @@
       }
     },
     "node_modules/@mov-ai/mov-fe-lib-react": {
-      "version": "1.0.34",
-      "resolved": "https://npm.pkg.github.com/download/@mov-ai/mov-fe-lib-react/1.0.34/b9a5d31cf776a8abc6c65ad69f104512fb60641892fbfbef848e3171cf472ab9",
-      "integrity": "sha512-EY0cs0oszdyGsp1PIM0XUjp3No6CrGq8G/mXkBXO6Qi6IryqUqV9MIarn6SUzzv4rhU5kvBhYTTaiawRfUt45g==",
+      "version": "1.0.37",
+      "resolved": "https://npm.pkg.github.com/download/@mov-ai/mov-fe-lib-react/1.0.37/a3ce1bc9cf9adaf46d6f28e7a0ebb81f874d0a797ef98d54317227d9f5ff347e",
+      "integrity": "sha512-HpqrboZavULQPKayHGKWz5PpGpGZzYiqnVT/q59aqJ78O7TA9P9msRtfnjmKDCI+2v5A43ISUPC53ccvDNfhTA==",
       "license": "ISC",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
@@ -28141,9 +28141,9 @@
       }
     },
     "@mov-ai/mov-fe-lib-react": {
-      "version": "1.0.34",
-      "resolved": "https://npm.pkg.github.com/download/@mov-ai/mov-fe-lib-react/1.0.34/b9a5d31cf776a8abc6c65ad69f104512fb60641892fbfbef848e3171cf472ab9",
-      "integrity": "sha512-EY0cs0oszdyGsp1PIM0XUjp3No6CrGq8G/mXkBXO6Qi6IryqUqV9MIarn6SUzzv4rhU5kvBhYTTaiawRfUt45g==",
+      "version": "1.0.37",
+      "resolved": "https://npm.pkg.github.com/download/@mov-ai/mov-fe-lib-react/1.0.37/a3ce1bc9cf9adaf46d6f28e7a0ebb81f874d0a797ef98d54317227d9f5ff347e",
+      "integrity": "sha512-HpqrboZavULQPKayHGKWz5PpGpGZzYiqnVT/q59aqJ78O7TA9P9msRtfnjmKDCI+2v5A43ISUPC53ccvDNfhTA==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@babylonjs/core": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@material-ui/styles": "^4.11.4",
     "@mov-ai/mov-fe-lib-code-editor": "^1.0.6",
     "@mov-ai/mov-fe-lib-core": "^1.0.36",
-    "@mov-ai/mov-fe-lib-react": "^1.0.34",
+    "@mov-ai/mov-fe-lib-react": "^1.0.37",
     "@remixproject/engine": "^0.3.19",
     "@remixproject/engine-web": "^0.3.19",
     "@testing-library/jest-dom": "^5.14.1",


### PR DESCRIPTION
Just a bump to lib-react version 1.0.37 (to be able to add icons to ContextMenus, and to be able to not render the handleToggleTheme)