### PR TITLE
[FP-1592] - Fixed start flow without link issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - [FP-1286 - Feature/fp 1286 port flow editor](https://movai.atlassian.net/browse/FP-1286)
 - [FP-1563 - Filtering new files from Flow Explorer](https://movai.atlassian.net/browse/FP-1563)
+- [FP-1592 - Fix start flow without link issue](https://movai.atlassian.net/browse/FP-1592)
 
 **Node Editor**
 

--- a/src/plugins/views/editors/Flow/Components/FlowTopBar/FlowTopBar.jsx
+++ b/src/plugins/views/editors/Flow/Components/FlowTopBar/FlowTopBar.jsx
@@ -261,6 +261,9 @@ const FlowTopBar = props => {
   const canRunFlow = useCallback(
     action => {
       const graph = mainInterface.current?.current?.graph;
+      // let's validate flow before continuing
+      graph?.validateFlow();
+
       const warnings = graph?.warnings || [];
       const warningsVisibility = graph.warningsVisibility;
       const runtimeWarnings = warnings.filter(wn => wn.isRuntime);

--- a/src/plugins/views/editors/Flow/Components/interface/MainInterface.js
+++ b/src/plugins/views/editors/Flow/Components/interface/MainInterface.js
@@ -178,6 +178,7 @@ export default class MainInterface {
   deleteLink = linkId => {
     this.modelView.current.deleteLink(linkId);
     this.graph.deleteLinks([linkId]);
+    this.graph.validateFlow();
   };
 
   addNode = name => {


### PR DESCRIPTION
- We are validating the flow when a new link is added, but
- We weren't validating the flow when a link was deleted, now we are, also
- We weren't validating the flow when a flow action was triggered (ie. Start Flow), now we are.