### PR TITLE
FP-1580 : Don't show success message after adding link in flow

### DIFF
--- a/src/plugins/views/editors/Flow/Flow.jsx
+++ b/src/plugins/views/editors/Flow/Flow.jsx
@@ -788,14 +788,6 @@ const Flow = (props, ref) => {
         });
       });
 
-      // Subscribe to add link event
-      mainInterface.events.onAddLink.subscribe(evtData =>
-        alert({
-          location: "snackbar",
-          message: "Link created"
-        })
-      );
-
       // Subscribe to canvas context menu
       mainInterface.mode.canvasCtxMenu.onEnter.subscribe(evtData => {
         const anchorPosition = {
@@ -909,8 +901,7 @@ const Flow = (props, ref) => {
       openDoc,
       handleContextClose,
       t,
-      openDialog,
-      alert
+      openDialog
     ]
   );
 


### PR DESCRIPTION
[FP-1580 : Don't show success message after adding link in flow](https://movai.atlassian.net/browse/FP-1580)

The default behavior of the app is to not show alert messages on each user interaction, but only when the user saves the document.

To follow this default behavior, when we add a link, the flow is not saved, therefore it shouldn't show any alert message to the user after doing so.

