### PR TITLE
FP-1692 : Allow '_' character to start param name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [FP-1612 - Only reset ports when need](https://movai.atlassian.net/browse/FP-1612)
 - [FP-1613 - No longer duplicating ports when type changes](https://movai.atlassian.net/browse/FP-1613)
 - [FP-1625 - Fixed a few issues regarding Node Editor](https://movai.atlassian.net/browse/FP-1625)
+- [FP-1692 - Allow '\_' character to start param name](https://movai.atlassian.net/browse/FP-1692)-
 
 **Home Tab**
 

--- a/src/plugins/views/editors/Node/Node.jsx
+++ b/src/plugins/views/editors/Node/Node.jsx
@@ -13,6 +13,7 @@ import {
   DIALOG_TITLE,
   DATA_TYPES,
   ROS_VALID_NAMES,
+  ROS_VALID_NAMES_VARIATION,
   PLUGINS,
   SCOPES,
   ALERT_SEVERITIES
@@ -63,7 +64,7 @@ const Node = (props, ref) => {
     (paramName, type, previousData) => {
       const typeName = DIALOG_TITLE[type.toUpperCase()] ?? type;
       const newName = paramName.name ?? paramName;
-      const re = ROS_VALID_NAMES;
+      const re = type === "ports" ? ROS_VALID_NAMES : ROS_VALID_NAMES_VARIATION;
       try {
         if (!paramName)
           throw new Error(

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -193,8 +193,25 @@ export const DEFAULT_KEY_VALUE_DATA = {
   value: ""
 };
 
+/**
+ * Used for Port Names
+ * We’re using a valid ROS validation which only allows for a name to begin with a letter, tilde (~) or a forward slash (/),
+ * and then followed by any letters, numbers, underscores and forward slash (/),
+ * but can’t have 2 underscores in a row;
+ */
 export const ROS_VALID_NAMES = new RegExp(
   /(?!.*__.*)^[a-zA-Z~/]{1}?[a-zA-Z0-9_/]*$/
+);
+
+/**
+ * Used for Parameters, Environment Variables and Command Line
+ * We’re using a variation of the valid ROS validation which only allows for a name to begin with a letter,
+ * tilde (~) or a forward slash (/), but also allowing the first character to be an underscore (_),
+ * and then followed by any letters, numbers, underscores and forward slash (/),
+ * but can’t have 2 underscores in a row;
+ */
+export const ROS_VALID_NAMES_VARIATION = new RegExp(
+  /(?!.*__.*)^[a-zA-Z_~/]{1}?[a-zA-Z0-9_/]*$/
 );
 
 export const ALERT_SEVERITIES = {


### PR DESCRIPTION
[FP-1692](https://movai.atlassian.net/browse/FP-1692)

- Allow '_' character to start param name (this is valid for Parameters, Environment Variables and Command Line vars)