### PR TITLE
FP-1713 : Keybinds were overriding modals on Flow Editor

### DIFF
--- a/src/models/Flow/Flow.js
+++ b/src/models/Flow/Flow.js
@@ -549,6 +549,7 @@ class Flow extends Model {
   }
 
   static SCOPE = "Flow";
+  static CLASSNAME = "flow-interface";
 
   static EXTENSION = ".flo";
 

--- a/src/plugins/views/editors/Flow/Components/interface/canvas.js
+++ b/src/plugins/views/editors/Flow/Components/interface/canvas.js
@@ -1,5 +1,6 @@
 import * as d3 from "d3";
 import { Subject } from "rxjs";
+import FlowModel from "../../../../../../models/Flow/Flow";
 import { defaultFunction } from "../../../../../../utils/Utils";
 import Factory from "../../Components/Nodes/Factory";
 import {
@@ -89,7 +90,10 @@ class Canvas {
       .attr("tabindex", "-1")
       .style("outline", "none")
       //.style("background-color", classes.flowEditor.interfaceColor)
-      .attr("class", `flow-interface ${classes.flowEditor.interfaceColor}`)
+      .attr(
+        "class",
+        `${FlowModel.CLASSNAME} ${classes.flowEditor.interfaceColor}`
+      )
       .call(this.zoomBehavior);
     return this;
   };

--- a/src/plugins/views/editors/Flow/Flow.jsx
+++ b/src/plugins/views/editors/Flow/Flow.jsx
@@ -12,6 +12,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import InfoIcon from "@material-ui/icons/Info";
 import Add from "@material-ui/icons/Add";
 import CompareArrowsIcon from "@material-ui/icons/CompareArrows";
+import FlowModel from "../../../../models/Flow/Flow";
 import { usePluginMethods } from "../../../../engine/ReactPlugin/ViewReactPlugin";
 import { withEditorPlugin } from "../../../../engine/ReactPlugin/EditorReactPlugin";
 import { FLOW_EXPLORER_PROFILE, PLUGINS } from "../../../../utils/Constants";
@@ -895,29 +896,37 @@ const Flow = (props, ref) => {
   /**
    * Handle copy node
    */
-  const handleCopyNode = useCallback(() => {
-    const selectedNodes = getSelectedNodes();
-    const nodesPos = selectedNodes.map(n =>
-      Vec2.of(n.center.xCenter, n.center.yCenter)
-    );
-    let center = nodesPos.reduce((e, x) => e.add(x), Vec2.ZERO);
-    center = center.scale(1 / selectedNodes.length);
-    // Nodes to copy
-    const nodesToCopy = {
-      nodes: selectedNodes.map(n => n.data),
-      flow: data.id,
-      nodesPosFromCenter: nodesPos.map(pos => pos.sub(center))
-    };
-    // Write nodes to copy to clipboard
-    clipboard.write(KEYS.NODES_TO_COPY, nodesToCopy);
-  }, [clipboard, getSelectedNodes, data.id]);
+  const handleCopyNode = useCallback(
+    evt => {
+      if (!document.activeElement.classList.contains(FlowModel.CLASSNAME))
+        return;
+      evt && evt.preventDefault();
+      const selectedNodes = getSelectedNodes();
+      const nodesPos = selectedNodes.map(n =>
+        Vec2.of(n.center.xCenter, n.center.yCenter)
+      );
+      let center = nodesPos.reduce((e, x) => e.add(x), Vec2.ZERO);
+      center = center.scale(1 / selectedNodes.length);
+      // Nodes to copy
+      const nodesToCopy = {
+        nodes: selectedNodes.map(n => n.data),
+        flow: data.id,
+        nodesPosFromCenter: nodesPos.map(pos => pos.sub(center))
+      };
+      // Write nodes to copy to clipboard
+      clipboard.write(KEYS.NODES_TO_COPY, nodesToCopy);
+    },
+    [clipboard, getSelectedNodes, data.id]
+  );
 
   /**
    * Handle paste nodes in canvas
    */
   const handlePasteNodes = useCallback(
     async evt => {
-      if (evt) evt.preventDefault();
+      if (!document.activeElement.classList.contains(FlowModel.CLASSNAME))
+        return;
+      evt && evt.preventDefault();
       const { args: position = getMainInterface().canvas.mousePosition } =
         contextMenuOptions || {};
       const nodesToCopy = clipboard.read(KEYS.NODES_TO_COPY);


### PR DESCRIPTION
[FP-1713](https://movai.atlassian.net/browse/FP-1713)

**THIS IS AN HOTFIX**

- If we tried to ctrl+c / ctrl+v on a monaco editor in a modal on the flow editor, the flow keybind (copy node / paste node) would be called instead of the default copy / paste.