### PR TITLE
FP-1735 : Fix systembar submenu not showing

### DIFF
--- a/src/plugins/views/SystemBar/styles.js
+++ b/src/plugins/views/SystemBar/styles.js
@@ -66,7 +66,7 @@ export const systemMenuItemStyles = makeStyles(theme => ({
     "& > .MuiButton-label": { paddingLeft: "10px" },
     "&:hover": {
       background: theme.palette.grey[900],
-      "& > .MuiButton-label > ul[class*=subMenuHolder]": {
+      "& > .MuiButton-label > ul": {
         opacity: "1",
         maxWidth: "500px"
       }


### PR DESCRIPTION
[FP-1735](https://movai.atlassian.net/browse/FP-1735)

**THIS IS AN HOTFIX**

- We are now picking the submenu by it's element instead of it's class (when we release the jss classes name will change, so we need to have this into account in the future)